### PR TITLE
compat: move cryolab item prototype next to entity

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -656,6 +656,7 @@ else
     data.raw.planet["nauvis"].localised_description={"planetslib-templates.planet-description-two-moons",{"space-location-description.nauvis"},"[planet=muluna]","[planet=lignumis]"}
 end
 
+require("prototypes.item.cryolab")
 require("prototypes.entity.cryolab")
 
 for _,lab in pairs(data.raw["lab"]) do

--- a/prototypes/item/cryolab.lua
+++ b/prototypes/item/cryolab.lua
@@ -1,0 +1,18 @@
+if data.raw["lab"]["biolab"] then
+    local cryolab=table.deepcopy(data.raw["item"]["biolab"])
+
+    cryolab.name="cryolab"
+    cryolab.place_result= "cryolab"
+
+    cryolab.icons = {
+        {
+            icon="__muluna-graphics__/graphics/photometric-lab/photometric-lab-icon.png",
+            icon_size=64,
+            scale=0.25,
+            --tint = {r=0.7,g=0.7,b=1}
+        },
+        
+    }
+    cryolab.default_import_location = "muluna"
+    data:extend{cryolab}
+end

--- a/prototypes/item/entity-items.lua
+++ b/prototypes/item/entity-items.lua
@@ -18,24 +18,6 @@ crusher_2.icon = "__muluna-graphics__/graphics/icons/crusher-2.png"
 crusher_2.localised_name = {"",{"item-name.crusher"}," 2"}
 crusher_2.order = "cb[crusher-2]"
 --local crusher_2=nil
-if data.raw["lab"]["biolab"] then
-    local cryolab=table.deepcopy(data.raw["item"]["biolab"])
-
-    cryolab.name="cryolab"
-    cryolab.place_result= "cryolab"
-
-    cryolab.icons = {
-        {
-            icon="__muluna-graphics__/graphics/photometric-lab/photometric-lab-icon.png",
-            icon_size=64,
-            scale=0.25,
-            --tint = {r=0.7,g=0.7,b=1}
-        },
-        
-    }
-    cryolab.default_import_location = "muluna"
-    data:extend{cryolab}
-end
     
 
 local space_platform_advanced = table.deepcopy(data.raw["item"]["space-platform-foundation"])


### PR DESCRIPTION
## Description:

Move `cryolab` item prototype creation from to just before `cryolab` entity prototype creation in `data-updates.lua`

## Motivation and Context:

There is a circular dependency right now:

Muluna depends on Titanium
Titanium depends on Krastorio2 Spaced Out
Krastorio2 Spaced out depends on Muluna

I believe the K2SO dependency on Muluna will be able to be removed if this change is made. K2SO uses an flib function that depends on the prototype for the `place_result` of an item existing when it is called on the item.

So, in Muluna, if the `cryolab` item creation is moved to the same place as entity creation, this should fix the issue and allow K2SO to remove the dep on Muluna and fix the dependency cycle.

An alternative fix would be to move the `cryolab` entity prototype creation to the data phase instead of data-updates, but I was not sure which would be best for Muluna.

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Not required when submitting locale changes when no locale exists yet.-->


## Checklist:

- [x ] My commit summaries follow the format of conventional commits described by [factorio-mod-template](https://github.com/fgardt/factorio-mod-template). 

    - Examples:

        - "locale: Added Chinese localisation."

        - "feat: Added Space Boiler. This is a boiler that consumes thruster oxidizer and produces steam."

        - "balance: Rebalanced Space boiler's recipe."
        
- [x ] I have verified that my commits do not cause the mod to crash on startup, either alone or with the following mods installed:

    - Alien Biomes

- [x ] I have tested control-level changes made by this PR to verify that it doesn't cause any crashes during typical gameplay. Absolute certainty is not required, but reasonable certainty is.

- [ ] If I am submitting locale changes, I have some knowledge of the language involved, either natively or as a second language, and this is not an unverified machine translation.


## Screenshots (if appropriate):