### PR TITLE
Add Automation science pack from Aluminum plates

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -305,7 +305,7 @@ muluna-hardcore-greenhouses-require-space-science=[color=orange][font=heading-2]
 muluna-hardcore-silicon-requires-space-science=[color=orange][font=heading-2]Roc's Hard Mode[/font][/color] Silicon processing technology requires [item=space-science-pack]
 muluna-change-quality-science-pack-drain=[color=cyan][font=heading-2]Other[/font][/color] Change science pack drain with quality
 nav-beacon-display-alert=Display alert when satellite radar is available in remote view
-muluna-alternative-automation-pack-recipe=[color=cyan][font=heading-2]Other[/font][/color] Add alternative Automation science pack recipe using aluminum
+muluna-alternative-automation-pack-recipe=[color=green][font=heading-2]Easy[/font][/color] Add alternative [item=automation-science-pack] Automation science pack recipe using aluminum
 muluna-new-interstellar-pack-recipe=[font=heading-2]Experimental[/font] Use new Interstellar science pack recipe
 muluna-easy-vanilla-rocket-part-costs=[color=green][font=heading-2]Easy[/font][/color] Use vanilla rocket part costs
 muluna-easy-simple-wood-gasification=[color=green][font=heading-2]Easy[/font][/color] Free productivity on wood gasification crafting chain
@@ -343,7 +343,7 @@ muluna-graphics-enable-footstep-animations=Footstep particles consume around 0.0
 muluna-easy-simple-nanofoamed-polymers=Simplifies the nanofoamed polymers crafting chain by making the spoilage of diffused plastic begin when crafted, rather than when beginning the craft.
 muluna-easy-revert-changes-to-space-platform-technology=Also reverts changes to space platform thruster technology to make standard thruster fuel/oxidizer recipes available before reaching Muluna.
 muluna-interstellar-science-pack-dynamic-packs-required=Half rounded up of all planetary science packs that contribute to the discovery of [technology=interstellar-science-pack] will be required, overriding the hardcoded value.
-muluna-alternative-automation-pack-recipe=Always enabled if the mod Any Planet Start is used with a Muluna start
+muluna-alternative-automation-pack-recipe=Allows the complete research of early technologies on Muluna. Always enabled with Muluna start.
 
 [nav-beacon]
 single-per-platform=Only one satellite radar can exist per Space Platform.

--- a/locale/fr/locale.cfg
+++ b/locale/fr/locale.cfg
@@ -137,7 +137,7 @@ disable-muluna-music=Désactiver la musique de Muluna
 override-space-connection=Rediriger les connexions spatiales vers Nauvis
 space-science-pack-output=Production du pack scientifique spatial
 space-science-pack-energy=Temps de fabrication du pack scientifique spatial
-muluna-alternative-automation-pack-recipe=[color=cyan][font=heading-2]Autre[/font][/color] Ajoute la recette alternative pour le pack de science d'Automatisation basée sur l'aluminium
+muluna-alternative-automation-pack-recipe=[color=green][font=heading-2]Facile[/font][/color] Ajoute la recette alternative pour le [item=automation-science-pack] pack de science d'Automatisation basée sur l'aluminium
 
 [mod-setting-description]
 override-space-connection=Modifie les connexions entre Nauvis et Vulcanus, Gleba, et Fulgora pour passer par Muluna. Cela forcera chaque plateforme en route vers Nauvis à devoir être reconfigurée manuellement.

--- a/prototypes/recipe/vanilla-alternate-recipes.lua
+++ b/prototypes/recipe/vanilla-alternate-recipes.lua
@@ -161,7 +161,7 @@ if not (settings.startup["aps-planet"] and settings.startup["aps-planet"].value 
     aluminum_red_science.icons=dual_icon("automation-science-pack","aluminum-plate")
     data:extend({aluminum_red_science})
 
-    rro.soft_insert(data.raw["technology"]["automation-science-pack"].effects,
+    rro.soft_insert(data.raw["technology"]["muluna-aluminum-processing"].effects,
     {
         type = "unlock-recipe",
         recipe = "automation-science-pack-muluna",

--- a/settings.lua
+++ b/settings.lua
@@ -140,6 +140,15 @@ data:extend{
         default_value = false,
         order = "bf",
       },
+      {
+        type = "bool-setting",
+        name = "muluna-alternative-automation-pack-recipe",
+        --localised_name = {"mod-setting-name.muluna-alternative-automation-pack-recipe"},
+        --localised_description={"mod-setting-des.muluna-alternative-automation-pack-recipe"},
+        setting_type = "startup",
+        default_value = false,
+        order = "bg"
+      },
       
       {
         type = "bool-setting",
@@ -280,15 +289,6 @@ data:extend{
       setting_type = "runtime-per-user",
       default_value = true,
       order = "ba"
-    },
-    {
-      type = "bool-setting",
-      name = "muluna-alternative-automation-pack-recipe",
-      localised_name = {"mod-setting-name.muluna-alternative-automation-pack-recipe"},
-      localised_description={"mod-setting-name.muluna-alternative-automation-pack-recipe"},
-      setting_type = "startup",
-      default_value = false,
-      order = "za"
     },
     -- {
     --   type = "bool-setting",


### PR DESCRIPTION
## Description:
Add a setting (default: false) to enable an alternative Automation science pack reicpe using Aluminum plates instead of copper.

## Motivation and Context:
Some people may want to produce basic science on Muluna even though they didn't play a Muluna start. See #298


## Checklist:

- [x] My commit summaries follow the format of conventional commits described by [factorio-mod-template](https://github.com/fgardt/factorio-mod-template). 

    - Examples:

        - "locale: Added Chinese localisation."

        - "feat: Added Space Boiler. This is a boiler that consumes thruster oxidizer and produces steam."

        - "balance: Rebalanced Space boiler's recipe."
        
- [x] I have verified that my commits do not cause the mod to crash on startup, either alone or with the following mods installed:

    - Alien Biomes

- [x] I have tested control-level changes made by this PR to verify that it doesn't cause any crashes during typical gameplay. Absolute certainty is not required, but reasonable certainty is.

- [x] If I am submitting locale changes, I have some knowledge of the language involved, either natively or as a second language, and this is not an unverified machine translation.


## Screenshots (if appropriate):
<img width="759" height="54" alt="image" src="https://github.com/user-attachments/assets/a81da977-b4ce-4001-8c58-c7cb99425e95" />

<img width="408" height="193" alt="image" src="https://github.com/user-attachments/assets/8de13f51-9cd5-46b5-a799-037c2e6586c4" />
