### PR TITLE
Fix #309, add missing prerequisites

### DIFF
--- a/wood-gasification/prototypes/technology.lua
+++ b/wood-gasification/prototypes/technology.lua
@@ -35,7 +35,7 @@ data:extend({
     name = "wood-gas-processing-to-crude-oil",
     icon = "__muluna-graphics__/graphics/wood-gasification/technology/wood-gas-processing-to-crude-oil.png",
     icon_size = 256,
-    prerequisites = {"wood-gas-processing"},
+    prerequisites = {"wood-gas-processing", "production-science-pack"},
     effects =
     {
       {
@@ -59,7 +59,7 @@ data:extend({
     name = "advanced-wood-gas-processing",
     icon = "__muluna-graphics__/graphics/wood-gasification/technology/advanced-wood-gas-processing.png",
     icon_size = 256,
-    prerequisites = {"wood-gas-processing"},
+    prerequisites = {"wood-gas-processing", "production-science-pack", "utility-science-pack"},
     effects =
     {
       {


### PR DESCRIPTION
## Description:
Fix #309, add missing prerequisites to the given technologies

## Motivation and Context:
Motivation & Context explained on issue #309

## Checklist:

- [ ] My commit summaries follow the format of conventional commits described by [factorio-mod-template](https://github.com/fgardt/factorio-mod-template). 

    - Examples:

        - "locale: Added Chinese localisation."

        - "feat: Added Space Boiler. This is a boiler that consumes thruster oxidizer and produces steam."

        - "balance: Rebalanced Space boiler's recipe."
        
- [YES ] I have verified that my commits do not cause the mod to crash on startup, either alone or with the following mods installed:

    - StandAlone - OK
    - Enable all the planets: 
        - Tech "Advanced wood gasification" is modified by lignumis, I think it's OK, because it's more general to wood processing
        - Tech "Diluted bitumen upgrading" is also modified by lignumis, this one I think needs a check in lignumis code

- [YES] I have tested control-level changes made by this PR to verify that it doesn't cause any crashes during typical gameplay. Absolute certainty is not required, but reasonable certainty is.

- [N/A ] If I am submitting locale changes, I have some knowledge of the language involved, either natively or as a second language, and this is not an unverified machine translation.


## Screenshots (if appropriate):
<img width="407" height="353" alt="image" src="https://github.com/user-attachments/assets/4287c17c-af60-4f7a-9c06-c3495c5721aa" />
<img width="286" height="338" alt="image" src="https://github.com/user-attachments/assets/0231c34a-5c82-4d19-a5af-d0178fd76edb" />
