### PR TITLE
Fix #320

### DIFF
--- a/prototypes/final-fixes/data-cells.lua
+++ b/prototypes/final-fixes/data-cells.lua
@@ -5,10 +5,10 @@ local am3 = data.raw["assembling-machine"]["assembling-machine-3"]
 
 
 for _,recipe in pairs(data.raw["recipe"]) do
-    if recipe.category == "crafting-with-fluid"  then
+    if rro.contains(am3.crafting_categories,recipe.category) then
         for _,input in pairs({recipe.ingredients,recipe.results}) do
             local i = 1
-            if rro.count(input,function(entry) return entry.type == "fluid" end) == 1 then
+            if rro.count(input,function(entry) return entry.type == "fluid" end) > 0 then
                 for _,recipe in pairs(input) do
                     if recipe.type == "fluid" and recipe.fluidbox_index == nil then
                         recipe.fluidbox_index = i


### PR DESCRIPTION
## Description:
This seems to fix #320 with Factorio Version 2.0.73

## Checklist:

- [X] My commit summaries follow the format of conventional commits described by [factorio-mod-template](https://github.com/fgardt/factorio-mod-template). 

    - Examples:

        - "locale: Added Chinese localisation."

        - "feat: Added Space Boiler. This is a boiler that consumes thruster oxidizer and produces steam."

        - "balance: Rebalanced Space boiler's recipe."
        
- [X] I have verified that my commits do not cause the mod to crash on startup, either alone or with the following mods installed:

    - Alien Biomes

- [X] I have tested control-level changes made by this PR to verify that it doesn't cause any crashes during typical gameplay. Absolute certainty is not required, but reasonable certainty is.

- [X] If I am submitting locale changes, I have some knowledge of the language involved, either natively or as a second language, and this is not an unverified machine translation.


## Screenshots (if appropriate):