### PR TITLE
Add basic compatibility with Enriching Industry (i.e. prevent Factorio crash)

### DIFF
--- a/prototypes/recipe/casting-recipes.lua
+++ b/prototypes/recipe/casting-recipes.lua
@@ -7,6 +7,7 @@ local function replace_metal(old_string)
     
     new_string = string.gsub(new_string,old_metal,new_metal,1)
     if new_string == "crushed-aluminum-ore" then new_string = "alumina-crushed" end
+    if new_string == "ei-enriched-aluminum-ore" then new_string = "alumina-crushed" end
     if new_string == "aluminum-ore" then new_string = "alumina" end
     if new_string == "aluminum-cable" then new_string = "copper-cable" end
     return new_string


### PR DESCRIPTION
…90dcc14469fd5bf and https://mods.factorio.com/mod/enriching-industry/discussion/697e0fc1f1e0b252904be1ce

## Description:
Add basic compatibility with Enriching Industry (i.e. prevent Factorio crash)

## Motivation and Context:
prevent Factorio crash
see https://github.com/nicholasgower/planet-muluna/issues/379


## Checklist:

- [ ] My commit summaries follow the format of conventional commits described by [factorio-mod-template](https://github.com/fgardt/factorio-mod-template). 

    - Examples:

        - "locale: Added Chinese localisation."

        - "feat: Added Space Boiler. This is a boiler that consumes thruster oxidizer and produces steam."

        - "balance: Rebalanced Space boiler's recipe."
        
- [ ] I have verified that my commits do not cause the mod to crash on startup, either alone or with the following mods installed:

    - Alien Biomes

- [ ] I have tested control-level changes made by this PR to verify that it doesn't cause any crashes during typical gameplay. Absolute certainty is not required, but reasonable certainty is.

- [ ] If I am submitting locale changes, I have some knowledge of the language involved, either natively or as a second language, and this is not an unverified machine translation.


## Screenshots (if appropriate):
seems to work:
<img width="415" height="437" alt="image" src="https://github.com/user-attachments/assets/33ad8a2a-e4c8-4453-90ea-2ee18e18053a" />
