### PR TITLE
fix: Fixed crash with Interstellar Travel caused by rro.replace creat…

### DIFF
--- a/lib/remove-replace-object.lua
+++ b/lib/remove-replace-object.lua
@@ -78,10 +78,12 @@ function rro.replace(list, objectToRemove, replacementObject)
                 if replacementObject ~= nil then
                     if type(replacementObject) == "function" then
                         list[i] = replacementObject(table.deepcopy(list[i]))
+                    elseif rro.contains(list, replacementObject) then
+                        table.remove(list, i) -- Remove the object if the replacement is already in the list, to avoid duplicates
                     else
                         list[i] = replacementObject -- Replace the object
                     end
-                    
+
                 else
                     table.remove(list, i) -- Remove the object if no replacement is provided
                 end

--- a/lib/remove-replace-object.lua
+++ b/lib/remove-replace-object.lua
@@ -67,8 +67,12 @@ function rro.remove(list, objectToRemove)
     end
 end
 
+function rro.replace_no_duplicates(list, objectToRemove, replacementObject)
+    rro.replace(list, objectToRemove, replacementObject,true) 
+end
+
 ---Replaces object in list with another object
-function rro.replace(list, objectToRemove, replacementObject) 
+function rro.replace(list, objectToRemove, replacementObject,no_duplicates) 
     if replacementObject == nil then
         error("Use rro.remove instead of rro.replace.")
     end
@@ -78,7 +82,7 @@ function rro.replace(list, objectToRemove, replacementObject)
                 if replacementObject ~= nil then
                     if type(replacementObject) == "function" then
                         list[i] = replacementObject(table.deepcopy(list[i]))
-                    elseif rro.contains(list, replacementObject) then
+                    elseif rro.contains(list, replacementObject) and no_duplicates then
                         table.remove(list, i) -- Remove the object if the replacement is already in the list, to avoid duplicates
                     else
                         list[i] = replacementObject -- Replace the object

--- a/prototypes/overrides/vanilla-overrides.lua
+++ b/prototypes/overrides/vanilla-overrides.lua
@@ -1,7 +1,7 @@
 local rro = Muluna.rro
 for _,tech in pairs(data.raw["technology"]) do
     if tech.prerequisites then
-        rro.replace_no_duplicates(tech.prerequisites,"space-platform-thruster","space-science-pack",true)
+        rro.replace_no_duplicates(tech.prerequisites,"space-platform-thruster","space-science-pack")
     end
     
 end

--- a/prototypes/overrides/vanilla-overrides.lua
+++ b/prototypes/overrides/vanilla-overrides.lua
@@ -1,7 +1,7 @@
 local rro = Muluna.rro
 for _,tech in pairs(data.raw["technology"]) do
     if tech.prerequisites then
-        rro.replace(tech.prerequisites,"space-platform-thruster","space-science-pack")
+        rro.replace_no_duplicates(tech.prerequisites,"space-platform-thruster","space-science-pack",true)
     end
     
 end


### PR DESCRIPTION
Root cause

  interstellar-travel defines core-system-travel with:

  prerequisites = { "space-science-pack", "space-platform-thruster" },

  Muluna's prototypes/overrides/vanilla-overrides.lua:4 runs over every technology:

  rro.replace(tech.prerequisites,"space-platform-thruster","space-science-pack")

  and rro.replace didn't check whether the replacement already exists in the list — so that tech ended up with space-science-pack twice, which Factorio rejects at prototype setup. (interstellar-travel loads
  before planet-muluna alphabetically with no dependency between them, so the tech exists when the override runs.)
