### PR TITLE
feat: Add aluminum-based battery recipe for Muluna

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -314,6 +314,7 @@ muluna-easy-simple-wood-gasification=[color=green][font=heading-2]Easy[/font][/c
 muluna-easy-simple-nanofoamed-polymers=[color=green][font=heading-2]Easy[/font][/color] Simple nanofoamed polymers
 muluna-easy-wood-gasification-productivity=[color=green][font=heading-2]Easy[/font][/color] Add wood gasification productivity technology
 muluna-easy-vanilla-advanced-thruster-fuel-costs=[color=green][font=heading-2]Easy[/font][/color] Use vanilla advanced thruster fuel/oxidizer costs
+muluna-easy-alternative-battery-recipe=[color=green][font=heading-2]Easy[/font][/color] Add alternative aluminum battery recipe
 muluna-interstellar-science-pack-packs-required=[color=blue][font=heading-2]Balance[/font][/color] Number of planetary science packs required to unlock [technology=interstellar-science-pack]
 muluna-interstellar-science-pack-dynamic-packs-required=[color=blue][font=heading-2]Balance[/font][/color] Adjust [technology=interstellar-science-pack] unlock requirements based on number of installed planets
 muluna-interstellar-science-pack-dynamic-packs-required-percentage-required=[color=blue][font=heading-2]Balance[/font][/color] Number of packs to unlock [technology=interstellar-science-pack](%)

--- a/prototypes/recipe/vanilla-alternate-recipes.lua
+++ b/prototypes/recipe/vanilla-alternate-recipes.lua
@@ -137,9 +137,22 @@ rro.replace_name(solar_panel.ingredients,"copper-plate","silicon-cell")
 rro.replace_name(solar_panel.ingredients,"steel-plate","aluminum-plate")
 
 
+-- Battery from aluminum instead of copper.
+-- The accumulator is assembled from batteries, and the vanilla battery uses a
+-- copper electrode. Aluminum electrodes work just as well in a sulfuric-acid
+-- cell, so on Muluna batteries can be crafted from abundant aluminum with no
+-- copper needed.
+local aluminum_battery = table.deepcopy(data.raw["recipe"]["battery"])
+aluminum_battery.name = "battery-from-aluminum"
+rro.replace_name(aluminum_battery.ingredients,"copper-plate","aluminum-plate")
+aluminum_battery.icons = dual_icon("battery","aluminum-plate")
+aluminum_battery.localised_name = {"recipe-name.x-from-aluminum",{"item-name.battery"}}
+aluminum_battery.allow_decomposition = false
+
+
 
 --local recipes = {motor_carbon, aluminum_rocket_fuel, carbon_nanotubes_lds, landfill_crushed_stone, bricks_crushed_stone,aluminum_green_circuit,aluminum_red_circuit, bio_plastic}
-local recipes = {motor_carbon,aluminum_rocket_fuel, carbon_nanotubes_lds, landfill_crushed_stone, bricks_crushed_stone,solar_panel}
+local recipes = {motor_carbon,aluminum_rocket_fuel, carbon_nanotubes_lds, landfill_crushed_stone, bricks_crushed_stone,solar_panel,aluminum_battery}
 --, ,aluminum_green_circuit,aluminum_red_circuit,
 for _,recipe in pairs(recipes) do
     if recipe.subgroup ~= data.raw["item"]["solar-panel"].subgroup then
@@ -152,6 +165,13 @@ end
 table.insert(recipes,bio_plastic)
 
 data:extend(recipes)
+
+-- Unlock the aluminum battery alongside the other aluminum-processing recipes.
+rro.soft_insert(data.raw["technology"]["muluna-aluminum-processing"].effects,
+{
+    type = "unlock-recipe",
+    recipe = "battery-from-aluminum",
+})
 
 
 -- Aluminum Automation science pack, only when not already added by the Any Planet Start compat

--- a/prototypes/recipe/vanilla-alternate-recipes.lua
+++ b/prototypes/recipe/vanilla-alternate-recipes.lua
@@ -137,22 +137,10 @@ rro.replace_name(solar_panel.ingredients,"copper-plate","silicon-cell")
 rro.replace_name(solar_panel.ingredients,"steel-plate","aluminum-plate")
 
 
--- Battery from aluminum instead of copper.
--- The accumulator is assembled from batteries, and the vanilla battery uses a
--- copper electrode. Aluminum electrodes work just as well in a sulfuric-acid
--- cell, so on Muluna batteries can be crafted from abundant aluminum with no
--- copper needed.
-local aluminum_battery = table.deepcopy(data.raw["recipe"]["battery"])
-aluminum_battery.name = "battery-from-aluminum"
-rro.replace_name(aluminum_battery.ingredients,"copper-plate","aluminum-plate")
-aluminum_battery.icons = dual_icon("battery","aluminum-plate")
-aluminum_battery.localised_name = {"recipe-name.x-from-aluminum",{"item-name.battery"}}
-aluminum_battery.allow_decomposition = false
-
 
 
 --local recipes = {motor_carbon, aluminum_rocket_fuel, carbon_nanotubes_lds, landfill_crushed_stone, bricks_crushed_stone,aluminum_green_circuit,aluminum_red_circuit, bio_plastic}
-local recipes = {motor_carbon,aluminum_rocket_fuel, carbon_nanotubes_lds, landfill_crushed_stone, bricks_crushed_stone,solar_panel,aluminum_battery}
+local recipes = {motor_carbon,aluminum_rocket_fuel, carbon_nanotubes_lds, landfill_crushed_stone, bricks_crushed_stone,solar_panel}
 --, ,aluminum_green_circuit,aluminum_red_circuit,
 for _,recipe in pairs(recipes) do
     if recipe.subgroup ~= data.raw["item"]["solar-panel"].subgroup then
@@ -166,12 +154,30 @@ table.insert(recipes,bio_plastic)
 
 data:extend(recipes)
 
--- Unlock the aluminum battery alongside the other aluminum-processing recipes.
-rro.soft_insert(data.raw["technology"]["muluna-aluminum-processing"].effects,
-{
-    type = "unlock-recipe",
-    recipe = "battery-from-aluminum",
-})
+if settings.startup["muluna-easy-alternative-battery-recipe"].value == true then
+    -- Battery from aluminum instead of copper.
+    -- The accumulator is assembled from batteries, and the vanilla battery uses a
+    -- copper electrode. Aluminum electrodes work just as well in a sulfuric-acid
+    -- cell, so on Muluna batteries can be crafted from abundant aluminum with no
+    -- copper needed.
+    local aluminum_battery = table.deepcopy(data.raw["recipe"]["battery"])
+    aluminum_battery.name = "muluna-battery-from-aluminum"
+    rro.replace_name(aluminum_battery.ingredients,"copper-plate","aluminum-plate")
+    aluminum_battery.icons = dual_icon("battery","aluminum-plate")
+    aluminum_battery.localised_name = {"recipe-name.x-from-aluminum",{"item-name.battery"}}
+    aluminum_battery.allow_decomposition = false
+
+    aluminum_battery.hide_from_signal_gui = false
+    aluminum_battery.auto_recycle = false
+    -- Unlock the aluminum battery alongside the other aluminum-processing recipes.
+    rro.soft_insert(data.raw["technology"]["muluna-aluminum-processing"].effects,
+    {
+        type = "unlock-recipe",
+        recipe = "muluna-battery-from-aluminum",
+    })
+    
+    data:extend{aluminum_battery}
+end
 
 
 -- Aluminum Automation science pack, only when not already added by the Any Planet Start compat

--- a/settings.lua
+++ b/settings.lua
@@ -147,6 +147,15 @@ data:extend{
         order = "bg",
         rocs_hard_mode = true,
       },
+      {
+        type = "bool-setting",
+        name = "muluna-easy-alternative-battery-recipe",
+        --localised_name = {"mod-setting-name.muluna-alternative-automation-pack-recipe"},
+        --localised_description={"mod-setting-des.muluna-alternative-automation-pack-recipe"},
+        setting_type = "startup",
+        default_value = false,
+        order = "bga",
+      },
       
       {
         type = "bool-setting",


### PR DESCRIPTION
  Aluminum can replace copper in batteries. The accumulator is assembled
  from batteries, and the vanilla battery uses a copper electrode. Aluminum
  electrodes work just as well in a sulfuric-acid cell, so since Muluna is
  rich in aluminum and has no native copper, this alternate recipe lets
  players craft batteries from aluminum-plate instead of relying on copper.

  The recipe is unlocked alongside the other recipes in the
  "muluna-aluminum-processing" technology, mirroring how the solar panel,
  low density structure, and automation science pack already offer
  aluminum alternatives.