### PR TITLE
Easier Muluna

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -263,6 +263,7 @@ local rocket_part_muluna = table.deepcopy(data.raw["recipe"]["rocket-part"])
 rocket_part_muluna.name = "rocket-part-muluna"
 rocket_part_muluna.surface_conditions = {
     {property = "gravity",
+    min = 0.05,
     max = 2,
     }   
 }
@@ -318,6 +319,14 @@ end
 
 
 
+if settings.startup["muluna-easy-muluna-rocket-bonus"].value then
+    rocket_part_muluna.energy_required = (rocket_part_muluna.energy_required or 30) / 2
+    table.insert(data.raw["technology"]["planet-discovery-muluna"].effects, {
+        type = "change-recipe-productivity",
+        recipe = "rocket-part-muluna",
+        change = 0.5
+    })
+end
 
 data:extend{rocket_part_muluna}
 
@@ -327,24 +336,26 @@ for _, silo in pairs(data.raw["rocket-silo"]) do
         silo.disabled_when_recipe_not_researched = true
     end
 end
-data.raw.recipe["space-science-pack"].surface_conditions = {
-    {property = "gravity",
-    min = 2,
-    max = 2,
-    },
-    {property = "oxygen",
-    min = 0,
-    max = 0,
-    },
-    PlanetsLib.surface_conditions.restrict_to_surface("muluna")
-}
+if not settings.startup["muluna-easy-t1-science-anywhere"].value then
+    data.raw.recipe["space-science-pack"].surface_conditions = {
+        {property = "gravity",
+        min = 2,
+        max = 2,
+        },
+        {property = "oxygen",
+        min = 0,
+        max = 0,
+        },
+        PlanetsLib.surface_conditions.restrict_to_surface("muluna")
+    }
 
-if mods["Krastorio2-spaced-out"] then
-    data.raw.recipe["kr-space-research-data"].surface_conditions = data.raw.recipe["space-science-pack"].surface_conditions
+    if mods["Krastorio2-spaced-out"] then
+        data.raw.recipe["kr-space-research-data"].surface_conditions = data.raw.recipe["space-science-pack"].surface_conditions
 
+    end
+
+    data.raw.recipe["interstellar-science-pack"].surface_conditions = data.raw.recipe["space-science-pack"].surface_conditions
 end
-
-data.raw.recipe["interstellar-science-pack"].surface_conditions = data.raw.recipe["space-science-pack"].surface_conditions
 
 -- rro.replace(data.raw["technology"]["planet-discovery-vulcanus"].prerequisites,"space-science-pack","asteroid-collector")
 -- rro.replace(data.raw["technology"]["planet-discovery-gleba"].prerequisites,"space-science-pack","asteroid-collector")
@@ -487,6 +498,12 @@ for _,planet in pairs(data.raw["planet"]) do
 
 
 rro.soft_insert(data.raw["technology"]["planet-discovery-aquilo"].prerequisites,"interstellar-science-pack")
+if settings.startup["muluna-easy-remove-aquilo-t2-gate"].value then
+    rro.remove(data.raw["technology"]["planet-discovery-aquilo"].prerequisites,"advanced-space-science-pack")
+    if data.raw["technology"]["planet-discovery-aquilo"].unit then
+        rro.remove(data.raw["technology"]["planet-discovery-aquilo"].unit.ingredients,{"advanced-space-science-pack","_any"})
+    end
+end
 --table.insert(data.raw["technology"]["promethium-science-pack"].prerequisites,"interstellar-science-pack")
 --data.raw["item"]["space-science-pack"].localised_name = {"item-name."}
 --data.raw["technology"]["space-science-pack"].localised_name = {"item-name.lunar-science-pack"}
@@ -841,43 +858,46 @@ PlanetsLib:update
 require("prototypes.technology.interstellar-technologies")
 
 
-local space_science_pack_advanced = table.deepcopy(data.raw["recipe"]["space-science-pack"])
-data.raw["recipe"]["space-science-pack"].order = data.raw["item"]["space-science-pack"].order .. "-2"
-data.raw["recipe"]["space-science-pack"].surface_conditions = {
-    {
-        property = "gravity",
-        min = 0,
-        max = 0,
-    },
-}
-space_science_pack_advanced.name = "space-science-pack-muluna"
-space_science_pack_advanced.localised_name = {"item-name.space-science-pack"}
---space_science_pack_advanced.icons = dual_icon("space-science-pack","asteroid-collector")
-data:extend{space_science_pack_advanced}
-
-if mods["Krastorio2-spaced-out"] then
-    local space_science_pack_advanced = table.deepcopy(data.raw["recipe"]["kr-space-research-data"])
-
-    space_science_pack_advanced.surface_conditions = {
+if not settings.startup["muluna-easy-t1-science-anywhere"].value then
+    local space_science_pack_advanced = table.deepcopy(data.raw["recipe"]["space-science-pack"])
+    data.raw["recipe"]["space-science-pack"].order = data.raw["item"]["space-science-pack"].order .. "-2"
+    data.raw["recipe"]["space-science-pack"].surface_conditions = {
         {
             property = "gravity",
             min = 0,
             max = 0,
         },
-        -- {
-        --     property = "oxygen",
-        --     min = 0,
-        --     max = 0,
-        -- },
     }
-    space_science_pack_advanced.name = "kr-space-research-data-advanced"
+    space_science_pack_advanced.name = "space-science-pack-muluna"
+    space_science_pack_advanced.localised_name = {"item-name.space-science-pack"}
     --space_science_pack_advanced.icons = dual_icon("space-science-pack","asteroid-collector")
     data:extend{space_science_pack_advanced}
-    rro.soft_insert(data.raw["technology"]["advanced-space-science-pack"].effects ,  {
-        type = "unlock-recipe",
-        recipe = space_science_pack_advanced.name
-    })
-    
+
+    if mods["Krastorio2-spaced-out"] then
+        local space_science_pack_advanced = table.deepcopy(data.raw["recipe"]["kr-space-research-data"])
+
+        space_science_pack_advanced.surface_conditions = {
+            {
+                property = "gravity",
+                min = 0,
+                max = 0,
+            },
+            -- {
+            --     property = "oxygen",
+            --     min = 0,
+            --     max = 0,
+            -- },
+        }
+        space_science_pack_advanced.name = "kr-space-research-data-advanced"
+        --space_science_pack_advanced.icons = dual_icon("space-science-pack","asteroid-collector")
+        data:extend{space_science_pack_advanced}
+        rro.soft_insert(data.raw["technology"]["advanced-space-science-pack"].effects ,  {
+            type = "unlock-recipe",
+            recipe = space_science_pack_advanced.name
+        })
+    end
+else
+    data.raw["technology"]["advanced-space-science-pack"].hidden = true
 end
 
 

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -338,6 +338,10 @@ muluna-interstellar-science-pack-packs-required=[color=blue][font=heading-2]Bala
 muluna-interstellar-science-pack-dynamic-packs-required=[color=blue][font=heading-2]Balance[/font][/color] Adjust [technology=interstellar-science-pack] unlock requirements based on number of installed planets
 muluna-interstellar-science-pack-dynamic-packs-required-percentage-required=[color=blue][font=heading-2]Balance[/font][/color] Number of packs to unlock [technology=interstellar-science-pack](%)
 muluna-easy-revert-changes-to-space-platform-technology=[color=green][font=heading-2]Easy[/font][/color] Revert changes to space platform technology(Early crushers/asteroid collectors)
+muluna-easy-t1-science-anywhere=[color=green][font=heading-2]Easy[/font][/color] Craft [item=space-science-pack] T1 space science anywhere once unlocked
+muluna-easy-remove-aquilo-t2-gate=[color=green][font=heading-2]Easy[/font][/color] Remove T2 space science gate from Aquilo
+muluna-easy-muluna-rocket-bonus=[color=green][font=heading-2]Easy[/font][/color] Add Muluna rocket production bonus
+muluna-easy-sulfur=[color=green][font=heading-2]Easy[/font][/color] Add Muluna-only carbonic asteroid crushing
 muluna-balance-fulgoran-cargo-drop-radius=[color=blue][font=heading-2]Balance[/font][/color] Spawned cargo drops spawn radius
 muluna-balance-fulgoran-cargo-drop-item-multiplier=[color=blue][font=heading-2]Balance[/font][/color] Spawned cargo drops loot multiplier
 muluna-balance-exploration-science-data-cost=[color=blue][font=heading-2]Balance[/font][/color] Exploration science pack astronomical data cost
@@ -365,6 +369,10 @@ muluna-easy-wood-gasification-productivity=Reduces the difficulty of producing o
 muluna-graphics-enable-footstep-animations=Footstep particles consume around 0.01 ms per player on Muluna per update. On massive servers, this may lead to performance issues.
 muluna-easy-simple-nanofoamed-polymers=Simplifies the nanofoamed polymers crafting chain by making the spoilage of diffused plastic begin when crafted, rather than when beginning the craft.
 muluna-easy-revert-changes-to-space-platform-technology=Also reverts changes to space platform thruster technology to make standard thruster fuel/oxidizer recipes available before reaching Muluna.
+muluna-easy-t1-science-anywhere=Removes the Muluna surface restriction from the T1 space science (interstellar science pack) recipe. Once unlocked through Muluna's normal progression, it can be crafted on any surface. Also hides the Advanced Space Science technology, which becomes redundant.
+muluna-easy-remove-aquilo-t2-gate=Removes T2 space science (advanced space science pack) as a prerequisite and research ingredient for the Aquilo discovery technology. The T1 space science gate remains.
+muluna-easy-muluna-rocket-bonus=Adds 50% base productivity and doubles the crafting speed of the Muluna rocket part recipe, making Muluna a production advantage rather than imposing a global penalty.
+muluna-easy-sulfur=Unlocks a Muluna-only copy of the carbonic asteroid crushing recipe, restricted to Muluna's surface. Provides a local source of sulfuric acid without requiring Gleba research.
 muluna-interstellar-science-pack-dynamic-packs-required=Half rounded up of all planetary science packs that contribute to the discovery of [technology=interstellar-science-pack] will be required, overriding the hardcoded value.
 muluna-alternative-automation-pack-recipe=Allows the complete research of early technologies on Muluna. Always enabled with Muluna start.
 

--- a/prototypes/recipe/crusher-recipes.lua
+++ b/prototypes/recipe/crusher-recipes.lua
@@ -353,4 +353,13 @@ data:extend{{
     results = {{type = "item", name = "muluna-basic-hard-drive", amount = 1}}, 
 }}
 
+if settings.startup["muluna-easy-sulfur"].value then
+    local copy = table.deepcopy(data.raw["recipe"]["advanced-carbonic-asteroid-crushing"])
+    copy.name = "muluna-advanced-carbonic-asteroid-crushing"
+    copy.enabled = false
+    copy.localised_name = {"", {"recipe-name.advanced-carbonic-asteroid-crushing"}, " (Muluna)"}
+    copy.surface_conditions = {{property = "is-muluna", min = 1}}
+    data:extend{copy}
+end
+
 

--- a/prototypes/technology/dependencies-updates.lua
+++ b/prototypes/technology/dependencies-updates.lua
@@ -7,9 +7,11 @@ local rro=Muluna.rro
 rro.replace(data.raw["technology"]["space-science-pack"].prerequisites,"space-platform","muluna-alice-propellant")
 table.insert(data.raw["technology"]["space-science-pack"].prerequisites,"muluna-steam-crusher")
 table.insert(data.raw["technology"]["space-science-pack"].prerequisites,"wood-gas-processing")
-for _,result in pairs(data.raw["technology"]["space-science-pack"].effects) do
-    if result.recipe == "space-science-pack" then
-        result.recipe = "space-science-pack-muluna"
+if not settings.startup["muluna-easy-t1-science-anywhere"].value then
+    for _,result in pairs(data.raw["technology"]["space-science-pack"].effects) do
+        if result.recipe == "space-science-pack" then
+            result.recipe = "space-science-pack-muluna"
+        end
     end
 end
 --table.insert(data.raw["technology"]["space-science-pack"].prerequisites,"muluna-oxide-asteroid-processing")

--- a/prototypes/technology/space-station.lua
+++ b/prototypes/technology/space-station.lua
@@ -1748,3 +1748,10 @@ if not data.raw["lab"]["biolab"] then
 
 
 data.raw["assembling-machine"]["crusher"].localised_description = {"entity-description.muluna-crusher"}
+
+if settings.startup["muluna-easy-sulfur"].value then
+    table.insert(data.raw["technology"]["carbonic-asteroid-crushing"].effects, {
+        type = "unlock-recipe",
+        recipe = "muluna-advanced-carbonic-asteroid-crushing"
+    })
+end

--- a/settings.lua
+++ b/settings.lua
@@ -156,7 +156,34 @@ data:extend{
         default_value = false,
         order = "bga",
       },
-      
+      {
+        type = "bool-setting",
+        name = "muluna-easy-t1-science-anywhere",
+        setting_type = "startup",
+        default_value = false,
+        order = "bh",
+      },
+      {
+        type = "bool-setting",
+        name = "muluna-easy-remove-aquilo-t2-gate",
+        setting_type = "startup",
+        default_value = false,
+        order = "bi",
+      },
+      {
+        type = "bool-setting",
+        name = "muluna-easy-muluna-rocket-bonus",
+        setting_type = "startup",
+        default_value = false,
+        order = "bj",
+      },
+      {
+        type = "bool-setting",
+        name = "muluna-easy-sulfur",
+        setting_type = "startup",
+        default_value = false,
+        order = "bk",
+      },
       {
         type = "bool-setting",
         name = "muluna-change-quality-science-pack-drain",


### PR DESCRIPTION
## Description:

Adds four opt-in balance settings (all default `false`) aimed at reducing friction in a Muluna playthrough:

1. **T1 science anywhere** (`muluna-easy-t1-science-anywhere`): Removes the Muluna surface restriction from the T1 space science (interstellar science pack) recipe. Once unlocked through normal Muluna progression, it can be crafted on any surface. Also hides the now-redundant Advanced Space Science technology.

2. **Remove Aquilo T2 gate** (`muluna-easy-remove-aquilo-t2-gate`): Removes T2 space science (advanced space science pack) as a prerequisite and research ingredient for the Aquilo discovery technology. The T1 science gate remains.

3. **Muluna rocket bonus** (`muluna-easy-muluna-rocket-bonus`): Adds 50% base productivity and doubles the crafting speed of the Muluna rocket part recipe, granting a production advantage rather than imposing a global cost penalty. Intended to be used in conjunction with `muluna-easy-vanilla-rocket-part-costs`.

4. **Muluna carbonic asteroid crushing** (`muluna-easy-sulfur`): Unlocks a Muluna-only copy of the advanced carbonic asteroid crushing recipe, restricted to Muluna's surface via `is-muluna` surface condition. Provides a local source of sulfur without requiring Gleba research.

Also fixes a bug where the Muluna rocket part recipe lacked a minimum gravity surface condition, allowing the productivity bonus to apply on space platforms. It didn't make any real difference (since you can't place a silo on a space platform) but it was weird when viewing the bonus (and the surfaces it applies to).

## Motivation and Context:

These changes are aimed at players who want more flexibility in how they progress through Muluna without being locked out of options on other surfaces. All changes are opt-in and off by default, so they have no impact on players who do not enable them.

## Checklist:

- [x] My commit summaries follow the format of conventional commits described by [factorio-mod-template](https://github.com/fgardt/factorio-mod-template).

- [x] I have verified that my commits do not cause the mod to crash on startup, either alone or with the following mods installed:

    - Alien Biomes

- [~] I have tested control-level changes made by this PR to verify that it doesn't cause any crashes during typical gameplay. Absolute certainty is not required, but reasonable certainty is.

- [~] If I am submitting locale changes, I have some knowledge of the language involved, either natively or as a second language, and this is not an unverified machine translation.
