### PR TITLE
compat: Raised Rigor Module version to 1.1.13 and switched to new API.

### DIFF
--- a/info.json
+++ b/info.json
@@ -22,7 +22,7 @@
     "space-exploration-graphics-4",
     "space-exploration-graphics",
     "? Moshine >= 1.1.1",
-    "+ rigor-module >= 1.1.8",
+    "+ rigor-module >= 1.1.13",
     "(?) aai-signal-transmission",
     "(?) orbital-transfer >= 0.2.3",
     "(?) alien-biomes",

--- a/prototypes/entity/crusher-2.lua
+++ b/prototypes/entity/crusher-2.lua
@@ -23,10 +23,7 @@ table.insert(crusher_2.crafting_categories,"muluna-crusher-2")
 crusher_2.localised_name={"",{"item-name.crusher"}," 2"}
 crusher_2.icon="__muluna-graphics__/graphics/icons/crusher-2.png"
 
-if mods["rigor-module"] then
-    
-    data.raw["mod-data"]["rigor_module_mod_data"].data["entity_to_base_rigor"][crusher_2.name]=50
-end
+crusher_2.rigor_base_value=mods["rigor-module"] and 50 or nil
 
 data:extend{crusher_2}
 

--- a/prototypes/recipe/asteroid-upcycling.lua
+++ b/prototypes/recipe/asteroid-upcycling.lua
@@ -29,7 +29,8 @@ if mods["quality"] then
             allow_quality=true,
             enabled = false,
             hide_from_signal_gui = false,
-            rigor_sensitivity=mods["rigor-module"] and 1 or nil
+            rigor_sensitivity=mods["rigor-module"] and 1 or nil,
+            rigor_compatibility_mode_whitelist=mods["rigor-module"] and true or nil
         })
         data:extend{new_recipe}
         table.insert(data.raw["technology"]["muluna-asteroid-upcycling"].effects, {

--- a/prototypes/recipe/crusher-recipes.lua
+++ b/prototypes/recipe/crusher-recipes.lua
@@ -297,7 +297,7 @@ for _,recipe in pairs(recipes) do
           recipe.hide_from_signal_gui = false
     end 
     if mods["rigor-module"] then
-        data.raw["mod-data"]["rigor_module_mod_data"].data.compatibility_mode_recipe_whitelist[recipe.name]=true
+        recipe.rigor_compatibility_mode_whitelist=true
     end
     
     

--- a/prototypes/recipe/gas-recipes.lua
+++ b/prototypes/recipe/gas-recipes.lua
@@ -463,6 +463,7 @@ local diffusion = {
             {type = "fluid",name = "carbon-dioxide", amount = 2.5} --Because I want to make finding the perfect combination of productivity vs speed more challenging
         },
         rigor_sensitivity=mods["rigor-module"] and 2 or nil,
+        rigor_compatibility_mode_whitelist=mods["rigor-module"] and true or nil,
         energy_required = 10,
         main_product = "muluna-diffused-plastic",
         --icons = data.raw["item"][].icons,
@@ -486,6 +487,7 @@ local diffusion = {
             reset_freshness_on_craft = settings.startup["muluna-easy-simple-nanofoamed-polymers"].value == true,
         })
     end
+    diffusion.results[2].rigor_product=mods["rigor-module"] and true or nil
 
 data:extend{diffusion}
 


### PR DESCRIPTION
## Don't merge until Rigor Module v1.1.13 is actually published!

## Description:
- Updated Rigor Module compat code for [API changes in v1.1.13](https://gitlab.com/jfletcher94/factorio-mods/-/merge_requests/74).
- Added `rigor_compatibility_mode_whitelist` to asteroid upcycling and diffused plastic recipes.

## Motivation and Context:
- Rigor Module API updated in v1.1.13 (still backwards compatible with old API for now)

## Checklist:

- [x] My commit summaries follow the format of conventional commits described by [factorio-mod-template](https://github.com/fgardt/factorio-mod-template). 

    - Examples:

        - "locale: Added Chinese localisation."

        - "feat: Added Space Boiler. This is a boiler that consumes thruster oxidizer and produces steam."

        - "balance: Rebalanced Space boiler's recipe."
        
- [x] I have verified that my commits do not cause the mod to crash on startup, either alone or with the following mods installed:

    - Alien Biomes

- [ ] I have tested control-level changes made by this PR to verify that it doesn't cause any crashes during typical gameplay. Absolute certainty is not required, but reasonable certainty is.

- [ ] If I am submitting locale changes, I have some knowledge of the language involved, either natively or as a second language, and this is not an unverified machine translation. I have also considered submitting locale changes to Muluna's dependencies, including PlanetsLib and Rigor Module.


## Screenshots (if appropriate):
