### PR TITLE
fix: Fixed usage of deprecated AmbientSound property removed in 2.1.13.

### DIFF
--- a/prototypes/sound/music.lua
+++ b/prototypes/sound/music.lua
@@ -4,7 +4,7 @@ if Muluna.rro.safe_get(settings.startup["disable-muluna-music"],{"value"}) == fa
     --     name = "muluna-sandy-boys-beth-cohens",
     --     type = "ambient-sound",
     --     track_type = "main-track",
-    --     planet = "muluna",
+    --     planets = {"muluna"},
     --     sound = {
     --         filename = "__muluna-graphics__/sound/music/1 - Sandy Boys Beth Cohen's [aiqbWEikr4w].ogg",
     --         volume = 0.7,
@@ -72,7 +72,7 @@ if Muluna.rro.safe_get(settings.startup["disable-muluna-music"],{"value"}) == fa
         track = Muluna.rro.merge({
             name = "muluna-music-" .. track.sound.filename,
             type = "ambient-sound",
-            planet = "muluna",
+            planets = {"muluna"},
             
         },track)
         if not track.track_type then track.track_type = "main-track" end


### PR DESCRIPTION
Fixes #451.

## Description:

Fixes crash on startup in 2.1.13.

## Motivation and Context:

Crash on startup bad.

## Checklist:

- [x] My commit summaries follow the format of conventional commits described by [factorio-mod-template](https://github.com/fgardt/factorio-mod-template). 

    - Examples:

        - "locale: Added Chinese localisation."

        - "feat: Added Space Boiler. This is a boiler that consumes thruster oxidizer and produces steam."

        - "balance: Rebalanced Space boiler's recipe."
        
- [x] I have verified that my commits do not cause the mod to crash on startup, either alone or with the following mods installed:

    - Alien Biomes

- [x] I have tested control-level changes made by this PR to verify that it doesn't cause any crashes during typical gameplay. Absolute certainty is not required, but reasonable certainty is.

- [x] If I am submitting locale changes, I have some knowledge of the language involved, either natively or as a second language, and this is not an unverified machine translation. I have also considered submitting locale changes to Muluna's dependencies, including PlanetsLib and Rigor Module.


## Screenshots (if appropriate):
